### PR TITLE
Remove explicit JQA plugins versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,6 @@
     </scm>
 
     <properties>
-        <jqa-java-plugin.version>2.1.0-M1</jqa-java-plugin.version>
-        <jqa-plugin-common.version>2.1.0-M1</jqa-plugin-common.version>
         <org.springframework.boot_version>3.2.2</org.springframework.boot_version>
         <org.springframework.data_version>3.2.2</org.springframework.data_version>
         <javax.transaction.transaction-api_version>1.3</javax.transaction.transaction-api_version>
@@ -75,20 +73,17 @@
         <dependency>
             <groupId>com.buschmais.jqassistant.plugin</groupId>
             <artifactId>java</artifactId>
-            <version>${jqa-java-plugin.version}</version>
         </dependency>
         <dependency>
             <groupId>com.buschmais.jqassistant.plugin</groupId>
             <artifactId>common</artifactId>
             <type>test-jar</type>
-            <version>${jqa-plugin-common.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.buschmais.jqassistant.plugin</groupId>
             <artifactId>java</artifactId>
             <type>test-jar</type>
-            <version>${jqa-java-plugin.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
They're already defined by jqa-distribution-specification BOM that is imported in org.jqassistant.plugin:parent