### PR TITLE
(ci) Restrict java versions used on CI builds to 17 and 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
   build:
     uses: jqassistant-tooling/jqassistant-github-actions/.github/workflows/ci.yml@main
     with:
+      java_test_versions: '[17, 21]' # use versions supported by last Spring version
       publish_snapshots: true
     secrets:
       ossrh_username: ${{ secrets.OSSRH_USERNAME }}


### PR DESCRIPTION
Since we use SpringBoot 3.x that requires java 17+