### PR TITLE
Remove usage of spring-boot-dependencies BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,18 +57,6 @@
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${org.springframework.boot_version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>com.buschmais.jqassistant.core</groupId>
@@ -127,11 +115,13 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <version>${org.springframework.boot_version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
+            <version>${org.springframework.boot_version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -143,6 +133,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <version>${org.springframework.boot_version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -154,11 +145,13 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web-services</artifactId>
+            <version>${org.springframework.boot_version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
+            <version>${org.springframework.boot_version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -176,13 +169,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-        </dependency>
-        <dependency>
-            <!-- Spring Boot BOM overwrites JAXB version used by jQA core -->
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
-            <version>2.4.0-b180830.0438</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
It added various side effect, by overriding managed dependencies defined in parent project.
E.g. changing lombok to a compile transitive dependency :(