### PR TITLE
Label only batch types contained in an artifact.

### DIFF
--- a/src/main/resources/META-INF/jqassistant-rules/spring-batch.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/spring-batch.xml
@@ -4,7 +4,7 @@
         <description>Labels all types implementing the interface "org.springframework.batch.item.ItemProcessor" with "Spring", "Batch" and "ItemProcessor".</description>
         <cypher><![CDATA[
             MATCH
-                (itemProcessor:Type)-[:EXTENDS|IMPLEMENTS*0..]->(interface:Type)
+                (artifact:Artifact)-[:CONTAINS]->(itemProcessor:Type)-[:EXTENDS|IMPLEMENTS*0..]->(interface:Type)
             WHERE
                 interface.fqn in [
                     "org.springframework.batch.item.ItemProcessor",
@@ -30,7 +30,7 @@
         <description>Labels all types implementing the interface "org.springframework.batch.item.ItemReader" with "Spring", "Batch" and "ItemReader".</description>
         <cypher><![CDATA[
             MATCH
-                (itemReader:Type)-[:EXTENDS|IMPLEMENTS*0..]->(interface:Type)
+                (artifact:Artifact)-[:CONTAINS]->(itemReader:Type)-[:EXTENDS|IMPLEMENTS*0..]->(interface:Type)
             WHERE
                 interface.fqn in [
                     "org.springframework.batch.item.ItemReader",
@@ -91,7 +91,7 @@
         <description>Labels all types implementing the interface "org.springframework.batch.item.ItemWriter" with "Spring", "Batch" and "ItemWriter".</description>
         <cypher><![CDATA[
             MATCH
-                (itemWriter:Type)-[:EXTENDS|IMPLEMENTS*0..]->(interface:Type)
+                (artifact:Artifact)-[:CONTAINS]->(itemWriter:Type)-[:EXTENDS|IMPLEMENTS*0..]->(interface:Type)
             WHERE
                 interface.fqn in [
                     "org.springframework.batch.item.ItemWriter",
@@ -143,7 +143,7 @@
         <description>Labels all types implementing the interface "org.springframework.batch.core.JobExecutionListener" with "Spring", "Batch" and "JobExecutionListener".</description>
         <cypher><![CDATA[
             MATCH
-                (jobExecutionListener:Type)-[:EXTENDS|IMPLEMENTS*0..]->(interface:Type)
+                (artifact:Artifact)-[:CONTAINS]->(jobExecutionListener:Type)-[:EXTENDS|IMPLEMENTS*0..]->(interface:Type)
             WHERE
                 interface.fqn in [
                     "org.springframework.batch.core.JobExecutionListener",
@@ -162,7 +162,7 @@
         <description>Labels all types implementing the interface "org.springframework.batch.core.step.tasklet.Tasklet" with "Spring", "Batch" and "Tasklet".</description>
         <cypher><![CDATA[
             MATCH
-                (tasklet:Type)-[:EXTENDS|IMPLEMENTS*0..]->(interface:Type)
+                (artifact:Artifact)-[:CONTAINS]->(tasklet:Type)-[:EXTENDS|IMPLEMENTS*0..]->(interface:Type)
             WHERE
                 interface.fqn in [
                     "org.springframework.batch.core.step.tasklet.Tasklet",

--- a/src/main/resources/META-INF/jqassistant-rules/spring-batch.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/spring-batch.xml
@@ -4,7 +4,7 @@
         <description>Labels all types implementing the interface "org.springframework.batch.item.ItemProcessor" with "Spring", "Batch" and "ItemProcessor".</description>
         <cypher><![CDATA[
             MATCH
-                (artifact:Artifact)-[:CONTAINS]->(itemProcessor:Type)-[:EXTENDS|IMPLEMENTS*0..]->(interface:Type)
+                (itemProcessor:Type)-[:EXTENDS|IMPLEMENTS]->(interface:Type)
             WHERE
                 interface.fqn in [
                     "org.springframework.batch.item.ItemProcessor",
@@ -30,7 +30,7 @@
         <description>Labels all types implementing the interface "org.springframework.batch.item.ItemReader" with "Spring", "Batch" and "ItemReader".</description>
         <cypher><![CDATA[
             MATCH
-                (artifact:Artifact)-[:CONTAINS]->(itemReader:Type)-[:EXTENDS|IMPLEMENTS*0..]->(interface:Type)
+                (itemReader:Type)-[:EXTENDS|IMPLEMENTS]->(interface:Type)
             WHERE
                 interface.fqn in [
                     "org.springframework.batch.item.ItemReader",
@@ -91,7 +91,7 @@
         <description>Labels all types implementing the interface "org.springframework.batch.item.ItemWriter" with "Spring", "Batch" and "ItemWriter".</description>
         <cypher><![CDATA[
             MATCH
-                (artifact:Artifact)-[:CONTAINS]->(itemWriter:Type)-[:EXTENDS|IMPLEMENTS*0..]->(interface:Type)
+                (itemWriter:Type)-[:EXTENDS|IMPLEMENTS]->(interface:Type)
             WHERE
                 interface.fqn in [
                     "org.springframework.batch.item.ItemWriter",
@@ -143,7 +143,7 @@
         <description>Labels all types implementing the interface "org.springframework.batch.core.JobExecutionListener" with "Spring", "Batch" and "JobExecutionListener".</description>
         <cypher><![CDATA[
             MATCH
-                (artifact:Artifact)-[:CONTAINS]->(jobExecutionListener:Type)-[:EXTENDS|IMPLEMENTS*0..]->(interface:Type)
+                (jobExecutionListener:Type)-[:EXTENDS|IMPLEMENTS]->(interface:Type)
             WHERE
                 interface.fqn in [
                     "org.springframework.batch.core.JobExecutionListener",
@@ -162,7 +162,7 @@
         <description>Labels all types implementing the interface "org.springframework.batch.core.step.tasklet.Tasklet" with "Spring", "Batch" and "Tasklet".</description>
         <cypher><![CDATA[
             MATCH
-                (artifact:Artifact)-[:CONTAINS]->(tasklet:Type)-[:EXTENDS|IMPLEMENTS*0..]->(interface:Type)
+                (tasklet:Type)-[:EXTENDS|IMPLEMENTS]->(interface:Type)
             WHERE
                 interface.fqn in [
                     "org.springframework.batch.core.step.tasklet.Tasklet",


### PR DESCRIPTION
The Spring interfaces 'org.springframework.batch.item.*' were not excluded from labeling. 